### PR TITLE
Initialize promotionName and chosenProducts state

### DIFF
--- a/force-app/main/default/lwc/promotionStateManager/promotionStateManager.js
+++ b/force-app/main/default/lwc/promotionStateManager/promotionStateManager.js
@@ -4,11 +4,11 @@ const promotionStateManager = defineState(
   ({ /** TODO FOR THE CHALLENGE: add the required properties here */ }) => {
 
     // TODO FOR THE CHALLENGE: Create a state property of type string to store promotion name
-    const promotionName;
+    const promotionName = '';
     
 
     // TODO FOR THE CHALLENGE: Create a state property of type array to store products
-    const chosenProducts;
+    const chosenProducts = [];
 
     const chosenStores = atom([]);
 


### PR DESCRIPTION
initialize the variables for below error 
Facing Error promotionStateManager LWC1503: Parsing error: Missing initializer in const declaration. (7:23) (7:23) error while deploying the code to org.